### PR TITLE
fix(test): TradeLegControllerTest - Fixed createTradeLeg endpoint val…

### DIFF
--- a/backend/src/main/java/com/technicalchallenge/controller/ConstraintsViolationExeption.java
+++ b/backend/src/main/java/com/technicalchallenge/controller/ConstraintsViolationExeption.java
@@ -1,0 +1,5 @@
+package com.technicalchallenge.controller;
+
+public class ConstraintsViolationExeption {
+
+}

--- a/backend/src/main/java/com/technicalchallenge/controller/TradeLegController.java
+++ b/backend/src/main/java/com/technicalchallenge/controller/TradeLegController.java
@@ -4,11 +4,17 @@ import com.technicalchallenge.dto.TradeLegDTO;
 import com.technicalchallenge.mapper.TradeLegMapper;
 import com.technicalchallenge.model.TradeLeg;
 import com.technicalchallenge.service.TradeLegService;
+
+import io.micrometer.core.ipc.http.HttpSender.Response;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
-
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
 
 import java.util.List;
@@ -66,4 +72,19 @@ public class TradeLegController {
         tradeLegService.deleteTradeLeg(id);
         return ResponseEntity.noContent().build();
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValid(MethodArgumentNotValidException e){
+        String message = e.getBindingResult().getFieldErrors().stream().map(DefaultMessageSourceResolvable::getDefaultMessage).findFirst().orElse("Validation failed");
+        return ResponseEntity.badRequest().body(message);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+public ResponseEntity<String> handleConstraintViolation(ConstraintViolationException e) {
+    String message = e.getConstraintViolations().stream()
+            .map(ConstraintViolation::getMessage)
+            .findFirst()
+            .orElse("Validation failed");
+    return ResponseEntity.badRequest().body(message);
+}
 }


### PR DESCRIPTION
…idation

- Problem: testCreateTradeLegValidationFailure_NegativeNotional expected HTTP 400 with message 'Notional must be positive', but the response body was empty.

- Root Cause: @Positive on notional triggered bean validation (MethodArgumentNotValidException) before the controller method ran, and the controller didn’t map the validation message to the response.

- Solution: Added local @ExceptionHandler methods in TradeLegController for MethodArgumentNotValidException and ConstraintViolationException to return 400 with the first validation error message.

- Impact: POST /api/tradeLegs now returns 400 with 'Notional must be positive' for negative or zero notional values, satisfying the test and improving validation consistency.