### PR TITLE
fix(test): BookServiceTest - Fixed mock BookMapper and stub mappings …

### DIFF
--- a/backend/src/test/java/com/technicalchallenge/service/BookServiceTest.java
+++ b/backend/src/test/java/com/technicalchallenge/service/BookServiceTest.java
@@ -1,8 +1,11 @@
 package com.technicalchallenge.service;
 
 import com.technicalchallenge.dto.BookDTO;
+import com.technicalchallenge.mapper.BookMapper;
 import com.technicalchallenge.model.Book;
 import com.technicalchallenge.repository.BookRepository;
+import com.technicalchallenge.repository.CostCenterRepository;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,6 +21,13 @@ import static org.mockito.Mockito.*;
 public class BookServiceTest {
     @Mock
     private BookRepository bookRepository;
+
+    @Mock
+    private BookMapper bookMapper;
+
+    @Mock
+    private CostCenterRepository costCenterRepository;
+
     @InjectMocks
     private BookService bookService;
 
@@ -26,6 +36,11 @@ public class BookServiceTest {
         Book book = new Book();
         book.setId(1L);
         when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+
+        BookDTO mapped = new BookDTO();
+        mapped.setId(1L);
+        when(bookMapper.toDto(book)).thenReturn(mapped);
+
         Optional<BookDTO> found = bookService.getBookById(1L);
         assertTrue(found.isPresent());
         assertEquals(1L, found.get().getId());
@@ -35,9 +50,13 @@ public class BookServiceTest {
     void testSaveBook() {
         Book book = new Book();
         book.setId(2L);
+
         BookDTO bookDTO = new BookDTO();
         bookDTO.setId(2L);
-        when(bookRepository.save(any(Book.class))).thenReturn(book);
+
+        when(bookMapper.toEntity(bookDTO)).thenReturn(book);
+        when(bookRepository.save(book)).thenReturn(book);
+        when(bookMapper.toDto(book)).thenReturn(bookDTO);
 
         BookDTO saved = bookService.saveBook(bookDTO);
         assertNotNull(saved);


### PR DESCRIPTION
…to prevent Null Point Exception.

- Problem: BookServiceTest caused errors with NullPointerException due to a null BookMapper.
- Root Cause: BookService depends on BookMapper and CostCenterRepository. The test only mocked BookRepository, so @InjectMocks created BookService with a null mapper. Also, BookMapper.toEntity(...) wasn’t stubbed, causing bookRepository.save(null).
- Solution: Added @Mock BookMapper and CostCenterRepository, stubbed toEntity/toDto in tests that use them, ensured bookRepository.save(...) is stubbed once with the mapped entity.
- Impact: Unblocks BookService tests, find-by-id and save scenarios now pass with proper mapping and without strict stubbing violations.